### PR TITLE
Implement Granian server and enhanced performance.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,4 @@ RUN chown -R app:app /usr/src/
 EXPOSE 8000
 
 # run the application.
-CMD ["mhcli", "server", "start", "app.main:app", "--host=0.0.0.0", "--port=8000"]
+CMD ["mhcli", "server", "start", "--interface",  "asgi", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -286,15 +286,82 @@ doc = ["sphinx (==4.3.2)", "sphinx-autodoc-typehints", "sphinx-rtd-theme", "sphi
 test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock", "mypy", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions"]
 
 [[package]]
-name = "h11"
-version = "0.14.0"
-description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+name = "granian"
+version = "1.2.3"
+description = "A Rust HTTP server for Python applications"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
-    {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
+    {file = "granian-1.2.3-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:799e36b0e1a22e80d8fe6870eef99e57e9225ea0aac8238e2768cfb5adb7a505"},
+    {file = "granian-1.2.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bc7fe81582530ed437dea89b894df58d3b17456540db50b4d252d2c7d515ed26"},
+    {file = "granian-1.2.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:65a5ee3de9be7fec9010ea2380c8a11d033f3bca658557faec61342b5a4540bd"},
+    {file = "granian-1.2.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b5fd6cc2a3b52a9b1aa108bb780b352751587b8540931b632e7af2f56e42fcc6"},
+    {file = "granian-1.2.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:ab53bda601d197854a05aa2f39e769f0f79b45b7790828e8387e504b6173b3a5"},
+    {file = "granian-1.2.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:478a39f8758c1c76c131abcbbad74c3ff97b1df901301e185efbf947f5876efd"},
+    {file = "granian-1.2.3-cp310-none-win_amd64.whl", hash = "sha256:4459c3539d41bfa631fa842d17aff540a9e8b481290bbccd420a2e960b0a019b"},
+    {file = "granian-1.2.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:811c0f89c48899cf804636cd6a4c528e2f8424436e4918354c8d3dc76ab8586a"},
+    {file = "granian-1.2.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7ac2a49c206871144a98f3765985d510c6b98f794d92f82866b76efeae26a7c8"},
+    {file = "granian-1.2.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:91ea7b762f25b56d3fe08ccedf727c5575f0a2aeee66d746f8d16c897324ea53"},
+    {file = "granian-1.2.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21ce487f4db3c51b271ba9eec4d413db1d89346a9c693a86a6cbcf87770fdbe0"},
+    {file = "granian-1.2.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:f5eedd857827cbc480e9c503231e623e3105d7d75b68e929897efb1fa98122a9"},
+    {file = "granian-1.2.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:912e8d411f11be0f34f8d0fea861624acbcc3a633e7460522074565d60343598"},
+    {file = "granian-1.2.3-cp311-none-win_amd64.whl", hash = "sha256:ad0273e3ce5f8e63490064d92592fb800a606f332a38854bdf4d57f2c56497dd"},
+    {file = "granian-1.2.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:2cf41f72b6e3a3725053a0158992d47708c8ab1289315913ac419dcad1299e1c"},
+    {file = "granian-1.2.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:51ed4e8e7b51d62edf16e3e7881f1bcba7b43074a5eed4724981ab471598d9f0"},
+    {file = "granian-1.2.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:084497b2a9fc5c3c1893854ef7d06ff08436cb8c84ad406827bbee365a29ba20"},
+    {file = "granian-1.2.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d36dd4ee113858d0dd531b13b8cc758cd772b4a1d29472bc0a9d0941176dfa06"},
+    {file = "granian-1.2.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:4f7fade5bac3c5ae92f3a507c35eade78818e1b00c5cfea50401ad4023d299a3"},
+    {file = "granian-1.2.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:086d66f9180b6b19c5f7e131bb2b927fc669511b71a8ec083b7466b5d7cb8893"},
+    {file = "granian-1.2.3-cp312-none-win_amd64.whl", hash = "sha256:02e718f9e7ab225436c15a816b78a9517dd0873fcc1e46d064aa78a542eb5c84"},
+    {file = "granian-1.2.3-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:13abe1a1f5d58f6963c93fa98b2fc6279aa272d397980b0d6674a9a3617c617b"},
+    {file = "granian-1.2.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:04b6dcd546c9e022d6c58bc8c051564dc51e409a57f6943231439d055fa7e7f5"},
+    {file = "granian-1.2.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7d48957027c592cc2f8438559cb439fe3bca2b881563d957f7a2cbf2e59d640b"},
+    {file = "granian-1.2.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22e3136c52bed36d6c3a3fac6c02030895170493b75532bdfbcd406bdfe8e9a4"},
+    {file = "granian-1.2.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:ccddc876086d0e87b2d7600126f3697913a4ffd8d05479f321a17d7d71718ce3"},
+    {file = "granian-1.2.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b76335657c888e2666da9ecb07cb580b22eb7536ca503f582b0892e05edb5523"},
+    {file = "granian-1.2.3-cp38-none-win_amd64.whl", hash = "sha256:b940c02b12c4bc398aec77b010bcf67faae5ea40e7f2b2e31a9952ad205b4bf5"},
+    {file = "granian-1.2.3-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:e00a9c5540c7f646c50653cb447524f068bfb0802098f5c20807f5624f672d75"},
+    {file = "granian-1.2.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e6d9ced4e541ae09a86a2e8a4e1f15d9390de9df482be7dd37f06bc32a5eaf17"},
+    {file = "granian-1.2.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b3bc78f88deb5657a0c4ce45f37a9c5729ee192af8d8c235240484af5dbf2d2d"},
+    {file = "granian-1.2.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b9c4915807cfeed7267e767fdcc4922a2250faa6b0d8cbdda3510d6814a5c36"},
+    {file = "granian-1.2.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:16f73c9c7e41e3e5d5435c224e05cf339feee37647c8df801909637fa9682ced"},
+    {file = "granian-1.2.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:63ae455d5e221a651fcdff9a71571857d64366fde8bd71e5cb7fb0e61e680002"},
+    {file = "granian-1.2.3-cp39-none-win_amd64.whl", hash = "sha256:da35eaa449ee30c3ca66bbc0655843e66e3e2d902054edffd8f1d0754c346e7f"},
+    {file = "granian-1.2.3-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:d3f900c3616985863b988125948ea243309042fb8ae746a4bbd1c909fd73a737"},
+    {file = "granian-1.2.3-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:e5405ccd1e82c008fb8549500ee733f8d705bdd8f95c2623a8205e865d3dcff2"},
+    {file = "granian-1.2.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4a7fc7a725c2ae4074180fd36bf0613fee527b91a0aa5d976bc24ef498c5e5f0"},
+    {file = "granian-1.2.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ea2b9d541a1164291d1747384644557e6375cb99932851a3450769f28a50eed3"},
+    {file = "granian-1.2.3-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:e074cce216abaf7847ee909610cd9194bf9c536a1fc0ed205c1c0068a6f5c1d8"},
+    {file = "granian-1.2.3-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:d27a7039e19b8b18ce21fa41cfd04ac4ef915bb69e7fd8b00ce6536d47eace35"},
+    {file = "granian-1.2.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:7808664729c4dbe92bb9b97a616822c8e5e495de82d2600aa5643566b859ac2a"},
+    {file = "granian-1.2.3-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0142793b9a2b3ef64c55e8a3af5402f7ab90745ffff12bf0675a4b726f7944d3"},
+    {file = "granian-1.2.3-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:6cc543f7dbd0f969676c71fa12aaec6d4557a0792b9efd565b8dc075eb8a2f93"},
+    {file = "granian-1.2.3-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:16ad4f8568ef4dc64f4e4fb1f9539125777455eb44477471c790c57f921fadd5"},
+    {file = "granian-1.2.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:719a622000677048fc9bb0795c967f9b33e63c4d08f71199f09810fedcdecb5b"},
+    {file = "granian-1.2.3-pp38-pypy38_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:dfe29e30530e890a9938dc3a125bf5e45086749b77ff8e999e744bb85a78e9eb"},
+    {file = "granian-1.2.3-pp38-pypy38_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:0077827d7cb620a8347db2c3abb9ecfbf69d67aa80ed6529a8eb17d5d9055621"},
+    {file = "granian-1.2.3-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:5537280c85f701ab5a0a8d07d31f90b10ad5372ed6691db2f5abe10e2ea158ac"},
+    {file = "granian-1.2.3-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:ed68616b5d23bd46987d5b27e4b726762d3267972d237c3d970aa9d8bef19bc3"},
+    {file = "granian-1.2.3-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:11bb7f4d730b79f536e3a5cce27d31ca7c2d5369a527539e89c0ba4ce1487aca"},
+    {file = "granian-1.2.3-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8027d341c348dd6b7960de6d0936cc42271fc2a9171d6d83425e12265421cd6"},
+    {file = "granian-1.2.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d559cee2696db8f2492fc360ad1f9da024ec0933647d9c67a487c71d0dc5d477"},
+    {file = "granian-1.2.3-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:dda1cfb983f8caeedcf25d8fa848f6179e6bd4344c926e384f77f2d38016fbfe"},
+    {file = "granian-1.2.3-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:6fdb5c22a404f0cc09f5e787b01ee9d6f4840e90602207a9a3fcb6074b25b0ff"},
+    {file = "granian-1.2.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:d28de1c0cc317c5c9cc633da5a89cedbbb895efc5af632f023686a15dae106c5"},
+    {file = "granian-1.2.3.tar.gz", hash = "sha256:bbc30c7874cd707ac88e8a4a2282f784a0bdd2ccaa71a3783f1ae1a75fdf19b1"},
 ]
+
+[package.dependencies]
+typer = ">=0.4.2,<0.12.0"
+uvloop = {version = ">=0.18.0,<0.19.0", markers = "sys_platform != \"win32\" and platform_python_implementation == \"CPython\""}
+
+[package.extras]
+all = ["granian[pname,reload]"]
+dev = ["granian[all,lint,test]"]
+lint = ["ruff (>=0.1.0,<0.2.0)"]
+pname = ["setproctitle (>=1.3.3,<1.4.0)"]
+reload = ["watchfiles (>=0.21,<1.0)"]
+test = ["httpx (>=0.25.0,<0.26.0)", "pytest (>=7.4.2,<7.5.0)", "pytest-asyncio (>=0.21.1,<0.22.0)", "websockets (>=11.0,<12.0)"]
 
 [[package]]
 name = "identify"
@@ -942,6 +1009,24 @@ files = [
 ]
 
 [[package]]
+name = "typer"
+version = "0.11.1"
+description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "typer-0.11.1-py3-none-any.whl", hash = "sha256:4ce7b2a60b8543816ca97d5ec016026cbe95d1a7a931083b988c1d3682548fe7"},
+    {file = "typer-0.11.1.tar.gz", hash = "sha256:f5ae987b97ebbbd59182f8e84407bbc925bc636867fa007bce87a7a71ac81d5c"},
+]
+
+[package.dependencies]
+click = ">=8.0.0"
+typing-extensions = ">=3.7.4.3"
+
+[package.extras]
+all = ["colorama (>=0.4.3,<0.5.0)", "rich (>=10.11.0,<14.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
+
+[[package]]
 name = "typing-extensions"
 version = "4.11.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -970,22 +1055,53 @@ socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
-name = "uvicorn"
-version = "0.29.0"
-description = "The lightning-fast ASGI server."
+name = "uvloop"
+version = "0.18.0"
+description = "Fast implementation of asyncio event loop on top of libuv"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.7.0"
 files = [
-    {file = "uvicorn-0.29.0-py3-none-any.whl", hash = "sha256:2c2aac7ff4f4365c206fd773a39bf4ebd1047c238f8b8268ad996829323473de"},
-    {file = "uvicorn-0.29.0.tar.gz", hash = "sha256:6a69214c0b6a087462412670b3ef21224fa48cae0e452b5883e8e8bdfdd11dd0"},
+    {file = "uvloop-0.18.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1f354d669586fca96a9a688c585b6257706d216177ac457c92e15709acaece10"},
+    {file = "uvloop-0.18.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:280904236a5b333a273292b3bcdcbfe173690f69901365b973fa35be302d7781"},
+    {file = "uvloop-0.18.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad79cd30c7e7484bdf6e315f3296f564b3ee2f453134a23ffc80d00e63b3b59e"},
+    {file = "uvloop-0.18.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99deae0504547d04990cc5acf631d9f490108c3709479d90c1dcd14d6e7af24d"},
+    {file = "uvloop-0.18.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:edbb4de38535f42f020da1e3ae7c60f2f65402d027a08a8c60dc8569464873a6"},
+    {file = "uvloop-0.18.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:54b211c46facb466726b227f350792770fc96593c4ecdfaafe20dc00f3209aef"},
+    {file = "uvloop-0.18.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:25b714f07c68dcdaad6994414f6ec0f2a3b9565524fba181dcbfd7d9598a3e73"},
+    {file = "uvloop-0.18.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1121087dfeb46e9e65920b20d1f46322ba299b8d93f7cb61d76c94b5a1adc20c"},
+    {file = "uvloop-0.18.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:74020ef8061678e01a40c49f1716b4f4d1cc71190d40633f08a5ef8a7448a5c6"},
+    {file = "uvloop-0.18.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f4a549cd747e6f4f8446f4b4c8cb79504a8372d5d3a9b4fc20e25daf8e76c05"},
+    {file = "uvloop-0.18.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:6132318e1ab84a626639b252137aa8d031a6c0550250460644c32ed997604088"},
+    {file = "uvloop-0.18.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:585b7281f9ea25c4a5fa993b1acca4ad3d8bc3f3fe2e393f0ef51b6c1bcd2fe6"},
+    {file = "uvloop-0.18.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:61151cc207cf5fc88863e50de3d04f64ee0fdbb979d0b97caf21cae29130ed78"},
+    {file = "uvloop-0.18.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c65585ae03571b73907b8089473419d8c0aff1e3826b3bce153776de56cbc687"},
+    {file = "uvloop-0.18.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e3d301e23984dcbc92d0e42253e0e0571915f0763f1eeaf68631348745f2dccc"},
+    {file = "uvloop-0.18.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:680da98f12a7587f76f6f639a8aa7708936a5d17c5e7db0bf9c9d9cbcb616593"},
+    {file = "uvloop-0.18.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:75baba0bfdd385c886804970ae03f0172e0d51e51ebd191e4df09b929771b71e"},
+    {file = "uvloop-0.18.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ed3c28337d2fefc0bac5705b9c66b2702dc392f2e9a69badb1d606e7e7f773bb"},
+    {file = "uvloop-0.18.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8849b8ef861431543c07112ad8436903e243cdfa783290cbee3df4ce86d8dd48"},
+    {file = "uvloop-0.18.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:211ce38d84118ae282a91408f61b85cf28e2e65a0a8966b9a97e0e9d67c48722"},
+    {file = "uvloop-0.18.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b0a8f706b943c198dcedf1f2fb84899002c195c24745e47eeb8f2fb340f7dfc3"},
+    {file = "uvloop-0.18.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:58e44650cbc8607a218caeece5a689f0a2d10be084a69fc32f7db2e8f364927c"},
+    {file = "uvloop-0.18.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:2b8b7cf7806bdc745917f84d833f2144fabcc38e9cd854e6bc49755e3af2b53e"},
+    {file = "uvloop-0.18.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:56c1026a6b0d12b378425e16250acb7d453abaefe7a2f5977143898db6cfe5bd"},
+    {file = "uvloop-0.18.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:12af0d2e1b16780051d27c12de7e419b9daeb3516c503ab3e98d364cc55303bb"},
+    {file = "uvloop-0.18.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b028776faf9b7a6d0a325664f899e4c670b2ae430265189eb8d76bd4a57d8a6e"},
+    {file = "uvloop-0.18.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:53aca21735eee3859e8c11265445925911ffe410974f13304edb0447f9f58420"},
+    {file = "uvloop-0.18.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:847f2ed0887047c63da9ad788d54755579fa23f0784db7e752c7cf14cf2e7506"},
+    {file = "uvloop-0.18.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6e20bb765fcac07879cd6767b6dca58127ba5a456149717e0e3b1f00d8eab51c"},
+    {file = "uvloop-0.18.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e14de8800765b9916d051707f62e18a304cde661fa2b98a58816ca38d2b94029"},
+    {file = "uvloop-0.18.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f3b18663efe0012bc4c315f1b64020e44596f5fabc281f5b0d9bc9465288559c"},
+    {file = "uvloop-0.18.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c6d341bc109fb8ea69025b3ec281fcb155d6824a8ebf5486c989ff7748351a37"},
+    {file = "uvloop-0.18.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:895a1e3aca2504638a802d0bec2759acc2f43a0291a1dff886d69f8b7baff399"},
+    {file = "uvloop-0.18.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4d90858f32a852988d33987d608bcfba92a1874eb9f183995def59a34229f30d"},
+    {file = "uvloop-0.18.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:db1fcbad5deb9551e011ca589c5e7258b5afa78598174ac37a5f15ddcfb4ac7b"},
+    {file = "uvloop-0.18.0.tar.gz", hash = "sha256:d5d1135beffe9cd95d0350f19e2716bc38be47d5df296d7cc46e3b7557c0d1ff"},
 ]
 
-[package.dependencies]
-click = ">=7.0"
-h11 = ">=0.8"
-
 [package.extras]
-standard = ["colorama (>=0.4)", "httptools (>=0.5.0)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "watchfiles (>=0.13)", "websockets (>=10.4)"]
+docs = ["Sphinx (>=4.1.2,<4.2.0)", "sphinx-rtd-theme (>=0.5.2,<0.6.0)", "sphinxcontrib-asyncio (>=0.3.0,<0.4.0)"]
+test = ["Cython (>=0.29.36,<0.30.0)", "aiohttp (==3.9.0b0)", "aiohttp (>=3.8.1)", "flake8 (>=5.0,<6.0)", "mypy (>=0.800)", "psutil", "pyOpenSSL (>=23.0.0,<23.1.0)", "pycodestyle (>=2.9.0,<2.10.0)"]
 
 [[package]]
 name = "virtualenv"
@@ -1010,4 +1126,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "3fb551c9c6a78d61542db93d8f2780452dc6ac5f90b3344dbe68fa613e462168"
+content-hash = "95e51c2736f89926c1defaf7c9a42a86e96f89a3d6ea525dbffe1e5eee8b0d28"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ version = "0.1.0"
 python = "^3.12"
 click = "^8.1.7"
 fastapi = "^0.110.2"
-uvicorn = "^0.29.0"
+granian = "^1.2.3"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.9.0"


### PR DESCRIPTION
## Purpose
This pull request transitions the project's server from Uvicorn to Granian to take advantage of Granian's more efficient handling of HTTP/1 and HTTP/2 protocols. It also refactors the Docker setup to run the Granian server, ensuring smoother startup and operation in containerized environments.

## List of Changes
- **Replaced Uvicorn with Granian:** Changed the project's server dependency from Uvicorn to Granian for enhanced performance and compatibility with newer HTTP protocols.
- **Implemented Granian Server in Development:** Configured the Granian server to be used in the development environment, ensuring all existing functionalities are supported.
- **Generic Server CLI Commands:** Introduced new CLI commands to manage the server more effectively, making it easier to start, stop, and restart the server during development.
- **Docker Startup Command Refactoring:** Updated the Docker container's startup command to initiate the Granian server, aligning the container operations with the new server setup.

## Linked Issues
Closes #3

## How to Test
To test these changes, follow these steps:
1. Pull the latest changes from the `philip/feat/granian` branch.
2. Ensure Docker is installed and running on your machine.
3. Navigate to the root directory of the project.
4. Run `docker-compose build` to rebuild the container with the new configurations.
5. Start the container using `docker-compose up` and observe the logs to ensure the Granian server starts without errors.
6. Navigate to `localhost:5000` to verify that the server is running and responding to requests correctly.

## Additional Information
Switching to Granian required updating several configurations, notably within the Docker setup and the command-line interface for server management. The integration was carefully tested to ensure compatibility with existing project structures and dependencies.
