### PR TITLE
Integrate mango-habanero-bot for automated bypass of protection ruleset.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
           echo "Building version: $version 🛠️."
 
+
   build-push:
     needs: [ versioning ]
     runs-on: ubuntu-latest
@@ -71,6 +72,13 @@ jobs:
       contents: write
       id-token: write
     steps:
+      - name: Generate mango habanero bot app token.
+        uses: actions/create-github-app-token@v1
+        id: mh-bot-token
+        with:
+            app_id: ${{ vars.MH_BOT_APP_ID }}
+            private_key: ${{ secrets.MH_BOT_PRIVATE_KEY }}
+
       - name: Checkout code.
         uses: actions/checkout@v4
         with:
@@ -82,4 +90,5 @@ jobs:
       - name: Python semantic release.
         uses: python-semantic-release/python-semantic-release@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.mh-bot-token.outputs.token }}
+          persist-credentials: false


### PR DESCRIPTION
## Purpose
This pull request introduces the integration of the mango-habanero-bot to safely bypass branch protection rulesets for release processes. This feature is designed to streamline the release workflow by allowing controlled automation to merge necessary changes without manual intervention, enhancing efficiency and reducing bottlenecks.

## List of Changes
- **Mango-Habanero-Bot Integration:** Implemented a bot that has the permissions to bypass branch protection rules specifically for merging release-related pull requests. This ensures that necessary updates, such as critical bug fixes or security updates, can be deployed swiftly and without delay.

## Linked Issues
N/A

## How to Test
1. Ensure the mango-habanero-bot is configured with the appropriate keys and permissions.
2. Trigger a release process that involves a pull request that would normally be blocked by branch protection rules.
3. Observe if the bot successfully bypasses the protection rules and merges the pull request without manual intervention.
4. Verify that all actions taken by the bot are logged for security and compliance purposes.
5. Check the stability and performance of the application post-merge to ensure that the integration does not introduce any unforeseen issues.

## Additional Information
The integration of this bot is a critical step towards automating our release process while maintaining high security and compliance standards. It is recommended that the operations team closely monitor the bot's activity during the initial deployment phase to fine-tune its configurations and ensure optimal performance.
